### PR TITLE
fix: fixed tips display to only display tips based on branch dependencies

### DIFF
--- a/Starter Application/app/src/main/java/com/example/b07demosummer2024/data/DataHandler.java
+++ b/Starter Application/app/src/main/java/com/example/b07demosummer2024/data/DataHandler.java
@@ -122,12 +122,35 @@ public class DataHandler {
         return stringToArray(rawAnswer);
     }
 
+    public ArrayList<String> getBranchIdsByQuestion(Question question) {
+        return getBranchIdsById(question.getId());
+    }
+
+    public ArrayList<String> getBranchIdsById(String questionId) {
+        JSONObject questionObject = questionsById.get(questionId);
+        if (questionObject == null) {
+            return new ArrayList<>();
+        }
+
+        try {
+            if (!questionObject.isNull("branches")) {
+                JSONObject branches = questionObject.getJSONObject("branches");
+                String raw = branches.getString(getAnswerById(questionId).get(0).replaceAll("\"", ""));
+                return stringToArray("[" + DataHandler.cleanString(raw) + "]");
+            }
+        } catch (JSONException e) {
+            Log.e("DataHandler", "Error getting branches for question: " + questionId, e);
+        }
+
+        return new ArrayList<>();
+    }
     public String getTipByQuestion(Question question) {
         return getTipById(question.getId());
     }
     public String getTipById(String questionId) {
         JSONObject questionObject = questionsById.get(questionId);
         if (questionObject == null) {
+            Log.d("abcde", "No question object found for: " + questionId);
             return "";
         }
 

--- a/Starter Application/app/src/main/java/com/example/b07demosummer2024/ui/tips/tipsFragment.java
+++ b/Starter Application/app/src/main/java/com/example/b07demosummer2024/ui/tips/tipsFragment.java
@@ -65,17 +65,45 @@ public class tipsFragment extends Fragment {
             ArrayList<String> strings = new ArrayList<>();
             ArrayList<Integer> images = new ArrayList<>();
 
+            LinkedHashMap<String, Question> questionsMap = JsonReader.getQuestionMap(getContext(), QUESTION_JSONS[0]);
+            LinkedHashMap<String, Question> questionsBranchesMap = JsonReader.getQuestionMap(getContext(), QUESTION_JSONS[1]);
+            LinkedHashMap<String, Question> questionsFollowupMap = JsonReader.getQuestionMap(getContext(), QUESTION_JSONS[2]);
+            ArrayList<String> toInclude = new ArrayList<>();
+
+            for (Question q : questionsMap.values()) {
+                toInclude.add(q.getId());
+
+                ArrayList<String> branches = dh.getBranchIdsByQuestion(q);
+                if (!branches.isEmpty()) {
+                    toInclude.addAll(branches);
+                }
+            }
+            for (Question q : questionsBranchesMap.values()) {
+                if (toInclude.contains(q.getId())) {
+                    ArrayList<String> branches = dh.getBranchIdsByQuestion(q);
+                    if (!branches.isEmpty()) {
+                        toInclude.addAll(branches);
+                    }
+                }
+            }
+
+            for (Question q : questionsFollowupMap.values()) {
+                toInclude.add(q.getId());
+            }
+
             for (String json : QUESTION_JSONS) {
                 LinkedHashMap<String, Question> questionMap = JsonReader.getQuestionMap(getContext(), json);
                 for (Question q : questionMap.values()) {
-                    String tip = dh.getTipByQuestion(q);
-                    if (tip != null && !tip.isEmpty()) {
-                        strings.add(tip);
-                        int resId = getContext().getResources().getIdentifier(q.getId(), "drawable", getContext().getPackageName());
-                        if (resId != 0) {
-                            images.add(resId);
-                        } else {
-                            images.add(R.drawable.no_image_found);
+                    if (toInclude.contains(q.getId())) {
+                        String tip = dh.getTipByQuestion(q);
+                        if (tip != null && !tip.isEmpty()) {
+                            strings.add(tip);
+                            int resId = getContext().getResources().getIdentifier(q.getId(), "drawable", getContext().getPackageName());
+                            if (resId != 0) {
+                                images.add(resId);
+                            } else {
+                                images.add(R.drawable.no_image_found);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
…cies

***Usage***: Do NOT edit `PULL_REQUEST_TEMPLATE.md` directly. When creating a PR, the template will be substituted into the comment space automatically.
Again, this is not to be edited and commited. To tick a checkbox, either write it as such:
- [x] Checked box

by using an `x` between the square brackets or save the message the tick the boxes after. Additionally, please request a second party to review the code before commiting during large changes.

# Description

Fix for tips page to display tips dynamically based on question responses and their corresponding branches

## Type of change

Please delete irrelevant options

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my code
- [x ] Unclear code blocks have been thoroughly commented
- [x ] I have updated corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [x ] New and existing unit tests pass locally with my changes
- [ x] Any new features are unittested with full coverage and are documented
